### PR TITLE
Fix not correct escaped blog title

### DIFF
--- a/_posts/2022-12-05-enumerate.md
+++ b/_posts/2022-12-05-enumerate.md
@@ -1,5 +1,5 @@
 ---
-title: "What's so hard about <code class=\"language-cpp\">views::enumerate</code>?"
+title: "What's so hard about views::enumerate?"
 category: c++
 tags:
   - c++


### PR DESCRIPTION
Hi Barry, thank you for your blog! I like it.

I detected a problem, and since I can not create an issue on your github pages repo, I create a PR instead, and add the problem description.

Please see the attached screen. Adding code formatting in the YAML front matter, the HTML escaping does not work for some reason. 

This makes illegal chars slip through in the title of the RSS blog, like `<` and `>`

The problematic text that gets into the title is: `<code class=" language-cpp">views::enumerate</code>` 

![Screenshot 2023-01-08 at 13 29 03](https://user-images.githubusercontent.com/6172295/211196244-4195eb3e-411a-4f26-9a61-4d2e75ca18eb.png)

Even standard browsers can not display the feed.

![Screenshot 2023-01-08 at 13 36 53](https://user-images.githubusercontent.com/6172295/211196399-0f4d7cd7-cecb-4758-b2d8-2a0d71d842a3.png)

The problem is that it makes some RSS readers crash, and that de-lists your blog from example  https://swedencpp.se/blogs , where it's normally listed. 